### PR TITLE
Solve build issue

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,7 @@ $ npm start
 
 # builds the release version with client assets in "build" directory
 $ npm run build
+----
 
 If you run into the following error:
 ```
@@ -54,7 +55,7 @@ you can solve the issue by running:
 export NODE_OPTIONS=--openssl-legacy-provider
 ```
 before running `npm start` or `npm run build`.
-----
+
 
 When running in "dev" mode, navigate to http://localhost:8080/webpack-dev-server/ to see the application.
 

--- a/README.adoc
+++ b/README.adoc
@@ -42,6 +42,18 @@ $ npm start
 
 # builds the release version with client assets in "build" directory
 $ npm run build
+
+If you run into the following error:
+```
+ERROR in ./src/assets/images/favicon.ico (./node_modules/file-loader/dist/cjs.js?name=[name].[ext]!./src/assets/images/favicon.ico)
+Module build failed (from ./node_modules/file-loader/dist/cjs.js):
+Error: error:0308010C:digital envelope routines::unsupported
+```
+you can solve the issue by running: 
+```
+export NODE_OPTIONS=--openssl-legacy-provider
+```
+before running `npm start` or `npm run build`.
 ----
 
 When running in "dev" mode, navigate to http://localhost:8080/webpack-dev-server/ to see the application.


### PR DESCRIPTION
This solves issue https://github.com/neo4j-examples/movies-javascript-bolt/issues/219.
As a new comer of the repo trying to run the code, here is the first thing which happens:

```
$ node --version
v19.4.0

$ npm run build 

> movies-neo4j-javascript-driver@0.0.1 build
> webpack

asset app.js 546 KiB [emitted] (name: app)
asset neo4j-web.min.js 452 KiB [emitted] [from: node_modules/neo4j-driver/lib/browser/neo4j-web.min.js] (auxiliary name: app)
asset index.html 3.25 KiB [emitted]
runtime modules 1.84 KiB 6 modules
cacheable modules 538 KiB
  modules by path ./src/ 6.95 KiB
    modules by path ./src/*.js 6.33 KiB
      ./src/app.js 3.03 KiB [built] [code generated]
        entry ./src/app.js null app 
      ./src/neo4jApi.js 3.29 KiB [built] [code generated]
        cjs require ./neo4jApi ./src/app.js 2:12-33 
    modules by path ./src/models/*.js 601 bytes
      ./src/models/Movie.js 341 bytes [built] [code generated]
        cjs self exports reference null ./src/models/Movie.js 19:0-14 
        cjs require ./models/Movie ./src/neo4jApi.js 2:14-39 
      ./src/models/MovieCast.js 260 bytes [built] [code generated]
        cjs self exports reference null ./src/models/MovieCast.js 16:0-14 
        cjs require ./models/MovieCast ./src/neo4jApi.js 3:18-47 
    ./node_modules/file-loader/dist/cjs.js?name=[name].[ext]!./src/assets/images/favicon.ico 39 bytes [built] [code generated] [1 error]
      cjs require file-loader?name=[name].[ext]!./assets/images/favicon.ico ./src/app.js 1:0-68 
  modules by path ./node_modules/ 531 KiB
    ./node_modules/file-loader/dist/cjs.js?name=[name].[ext]!./node_modules/neo4j-driver/lib/browser/neo4j-web.min.js 60 bytes [built] [code generated]
      cjs require file-loader?name=[name].[ext]!../node_modules/neo4j-driver/lib/browser/neo4j-web.min.js ./src/neo4jApi.js 1:0-98 
    ./node_modules/lodash/lodash.js 531 KiB [built] [code generated]
      from origin ./node_modules/lodash/lodash.js
        cjs self exports reference null ./node_modules/lodash/lodash.js 439:50-57 
        cjs self exports reference null ./node_modules/lodash/lodash.js 439:62-78 
        cjs self exports reference null ./node_modules/lodash/lodash.js 439:82-89 
        module decorator null ./node_modules/lodash/lodash.js 442:63-69 
        module decorator null ./node_modules/lodash/lodash.js 442:74-80 
        module decorator null ./node_modules/lodash/lodash.js 442:93-99 
        cjs self exports reference null ./node_modules/lodash/lodash.js 17209:7-11 
      cjs require lodash ./src/models/Movie.js 1:10-27 
      cjs require lodash ./src/models/MovieCast.js 1:10-27 
      cjs require lodash ./src/neo4jApi.js 4:10-27 

ERROR in ./src/assets/images/favicon.ico (./node_modules/file-loader/dist/cjs.js?name=[name].[ext]!./src/assets/images/favicon.ico)
Module build failed (from ./node_modules/file-loader/dist/cjs.js):
Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:140:10)
    at getHashDigest (/Users/some/path/lemql/node_modules/file-loader/node_modules/loader-utils/lib/getHashDigest.js:46:34)
    at /Users/some/path/lemql/node_modules/file-loader/node_modules/loader-utils/lib/interpolateName.js:113:11
    at String.replace (<anonymous>)
    at interpolateName (/Users/some/path/lemql/node_modules/file-loader/node_modules/loader-utils/lib/interpolateName.js:110:8)
    at Object.loader (/Users/some/path/lemql/node_modules/file-loader/dist/index.js:29:48)
 @ ./src/app.js 1:0-68

webpack 5.69.1 compiled with 1 error in 482 ms
```
